### PR TITLE
Add missing onReset at the end of Holt constructor

### DIFF
--- a/src/holt.cpp
+++ b/src/holt.cpp
@@ -263,6 +263,7 @@ struct Holt : Module {
         configParam(POLES_PARAM, 0.f, 1.f, 1.f, "Poles");
 
         quality = loadQuality();
+        onReset();
     }
 
     void onSampleRateChange() override


### PR DESCRIPTION
All other modules have it except this one.
Looking around in the code seems to me that without it a few things would start uninitialized, this should fix it.
