### PR TITLE
Prepare for v2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "rackwindows",
   "name": "Rackwindows",
-  "version": "1.1.2",
+  "version": "2.1.2",
   "license": "MIT",
   "brand": "Rackwindows",
   "author": "Jens Robert Janke",

--- a/src/bitshiftgain.cpp
+++ b/src/bitshiftgain.cpp
@@ -3,7 +3,7 @@ Dual BSG
 --------
 VCV Rack module based on BitshiftGain by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - 2 BSG units
@@ -52,7 +52,15 @@ struct Bitshiftgain : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(SHIFT_A_PARAM, -8.0, 8.0, 0.0, "Shift");
         configParam(SHIFT_B_PARAM, -8.0, 8.0, 0.0, "Shift/Offset");
-        configParam(LINK_PARAM, 0.f, 1.f, 0.0, "Link");
+        configSwitch(LINK_PARAM, 0.f, 1.f, 0.0, "Link", {"Not linked", "Linked"});
+
+        configInput(IN_A_INPUT, "Signal A");
+        configInput(IN_B_INPUT, "Signal B");
+        configOutput(OUT_A_OUTPUT, "Signal A");
+        configOutput(OUT_B_OUTPUT, "Signal B");
+
+        configBypass(IN_A_INPUT, OUT_A_OUTPUT);
+        configBypass(IN_B_INPUT, OUT_B_OUTPUT);
 
         onReset();
     }

--- a/src/capacitor.cpp
+++ b/src/capacitor.cpp
@@ -3,7 +3,7 @@ Capacitor
 ---------
 VCV Rack module based on Capacitor by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - mono
@@ -79,6 +79,13 @@ struct Capacitor : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(LOWPASS_PARAM, 0.f, 1.f, 1.f, "Lowpass");
         configParam(HIGHPASS_PARAM, 0.f, 1.f, 0.f, "Highpass");
+
+        configInput(LOWPASS_CV_INPUT, "Lowpass CV");
+        configInput(HIGHPASS_CV_INPUT, "Highpass CV");
+        configInput(IN_INPUT, "Signal");
+        configOutput(OUT_OUTPUT, "Signal");
+
+        configBypass(IN_INPUT, OUT_OUTPUT);
 
         quality = loadQuality();
         onReset();

--- a/src/capacitor_stereo.cpp
+++ b/src/capacitor_stereo.cpp
@@ -3,7 +3,7 @@ Capacitor Stereo
 ----------------
 VCV Rack module based on Capacitor by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - separate controls for left and right channels
@@ -101,7 +101,20 @@ struct Capacitor_stereo : Module {
         configParam(HIGHPASS_L_PARAM, 0.f, 1.f, 0.f, "Highpass L");
         configParam(HIGHPASS_R_PARAM, 0.f, 1.f, 0.f, "Highpass R");
         configParam(DRYWET_PARAM, 0.f, 1.f, 1.f, "Dry/Wet");
-        configParam(LINK_PARAM, 0.f, 1.f, 1.f, "Link");
+        configSwitch(LINK_PARAM, 0.f, 1.f, 1.f, "Link", {"Not linked", "Linked"});
+
+        configInput(LOWPASS_CV_L_INPUT, "Lowpass L CV");
+        configInput(LOWPASS_CV_R_INPUT, "Lowpass R CV");
+        configInput(HIGHPASS_CV_L_INPUT, "Highpass L CV");
+        configInput(HIGHPASS_CV_R_INPUT, "Highpass R CV");
+        configInput(DRYWET_CV_INPUT, "Dry/wet CV");
+        configInput(IN_L_INPUT, "Signal L");
+        configInput(IN_R_INPUT, "Signal R");
+        configOutput(OUT_L_OUTPUT, "Signal L");
+        configOutput(OUT_R_OUTPUT, "Signal R");
+
+        configBypass(IN_L_INPUT, OUT_L_OUTPUT);
+        configBypass(IN_R_INPUT, OUT_R_OUTPUT);
 
         isLinked = true;
         quality = loadQuality();
@@ -181,7 +194,7 @@ struct Capacitor_stereo : Module {
 
         drywetParam = drywet.getValue();
         drywetParam += drywetCv.getVoltage() / 5;
-        drywetParam = clamp(drywetParam, 0.01f, 0.99f);
+        drywetParam = clamp(drywetParam, 0.00f, 1.00f);
 
         double lowpassSpeed;
         double highpassSpeed;

--- a/src/chorus.cpp
+++ b/src/chorus.cpp
@@ -3,7 +3,7 @@ Chorus
 ------
 VCV Rack module based on Chorus by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - ensemble switch: changes behaviour to ChorusEnsemble
@@ -84,7 +84,17 @@ struct Chorus : Module {
         configParam(SPEED_PARAM, 0.f, 1.f, 0.5f, "Speed");
         configParam(RANGE_PARAM, 0.f, 1.f, 0.f, "Range");
         configParam(DRYWET_PARAM, 0.f, 1.f, 1.f, "Dry/Wet");
-        configParam(ENSEMBLE_PARAM, 0.f, 1.f, 0.f, "Ensemble");
+        configSwitch(ENSEMBLE_PARAM, 0.f, 1.f, 0.f, "Ensemble", {"Off", "On"});
+
+        configInput(SPEED_CV_INPUT, "Speed CV");
+        configInput(RANGE_CV_INPUT, "Range CV");
+        configInput(IN_L_INPUT, "Signal L");
+        configInput(IN_R_INPUT, "Signal R");
+        configOutput(OUT_L_OUTPUT, "Signal L");
+        configOutput(OUT_R_OUTPUT, "Signal R");
+
+        configBypass(IN_L_INPUT, OUT_L_OUTPUT);
+        configBypass(IN_R_INPUT, OUT_R_OUTPUT);
 
         quality = loadQuality();
         isEnsemble = false;

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -63,6 +63,19 @@ struct Console : Module {
     {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
 
+        for (int i = 0; i < 9; i++) {
+            configInput(IN_L_INPUTS + i, string::f("Channel %d L", i + 1));
+            configInput(IN_R_INPUTS + i, string::f("Channel %d R", i + 1));
+        }
+        configInput(IN_ST_L_INPUT, "Stereo Channel L");
+        configInput(IN_ST_R_INPUT, "Stereo Channel R");
+
+        configOutput(OUT_L_OUTPUT, "Mixed L");
+        configOutput(OUT_R_OUTPUT, "Mixed R");
+
+        configBypass(IN_L_INPUTS + 0, OUT_L_OUTPUT);
+        configBypass(IN_R_INPUTS + 0, OUT_R_OUTPUT);
+
         quality = loadQuality();
         consoleType = loadConsoleType();
         lightDivider.setDivision(512);
@@ -150,9 +163,9 @@ struct Console : Module {
 
     float consoleChannel(Input& input, long double mix[], int numChannels)
     {
-        if (input.isConnected()) {
-            float sum = 0.0f;
+        float sum = 0.0f;
 
+        if (input.isConnected()) {
             // input
             float inputSamples[16] = {};
             input.readVoltages(inputSamples);
@@ -180,8 +193,9 @@ struct Console : Module {
                 // add to mix
                 mix[i] += inputSample;
             }
-            return sum;
         }
+
+        return sum;
     }
 
     void consoleBuss(Output& output, long double mix[], int maxChannels)

--- a/src/console_mm.cpp
+++ b/src/console_mm.cpp
@@ -68,6 +68,15 @@ struct Console_mm : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(LEVEL_PARAM, -1.f, 1.f, 0.f, "Drive", "%", 0.f, 100.f);
 
+        configInput(IN_INPUTS + 0, "Poly 1-8");
+        configInput(IN_INPUTS + 1, "Poly 9-16");
+        configInput(IN_INPUTS + 2, "Poly Grp/Aux");
+        configOutput(DIRECT_OUTPUTS + 0, "Poly 1-8");
+        configOutput(DIRECT_OUTPUTS + 1, "Poly 9-16");
+        configOutput(DIRECT_OUTPUTS + 2, "Poly Grp/Aux");
+        configOutput(OUT_OUTPUTS + 0, "Mix L");
+        configOutput(OUT_OUTPUTS + 1, "Mix R");
+
         quality = loadQuality();
         consoleType = loadConsoleType();
         directOutMode = loadDirectOutMode();

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -3,7 +3,7 @@ Distance
 --------
 VCV Rack module based on Distance by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - mono
@@ -73,6 +73,13 @@ struct Distance : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(DISTANCE_PARAM, 0.f, 1.f, 0.f, "Distance");
         configParam(DRYWET_PARAM, 0.f, 1.f, 1.f, "Dry/Wet");
+
+        configInput(DISTANCE_CV_INPUT, "Distance CV");
+        configInput(DRYWET_CV_INPUT, "Dry/wet CV");
+        configInput(IN_INPUT, "Signal");
+        configOutput(OUT_OUTPUT, "Signal");
+
+        configBypass(IN_INPUT, OUT_OUTPUT);
 
         quality = loadQuality();
         onReset();

--- a/src/golem.cpp
+++ b/src/golem.cpp
@@ -68,7 +68,16 @@ struct Golem : Module {
         configParam(OFFSET_PARAM, -1.f, 1.f, 0.f, "Offset");
         configParam(BALANCE_TRIM_PARAM, -1.f, 1.f, 0.f, "Balance CV");
         configParam(OFFSET_TRIM_PARAM, -1.f, 1.f, 0.f, "Offset CV");
-        configParam(PHASE_PARAM, 0.f, 2.f, 0.f, "Phase");
+        configSwitch(PHASE_PARAM, 0.f, 2.f, 0.f, "Phase", {"Off", "Flip polarity channel A", "Flip polarity channel B"});
+
+        configInput(BALANCE_CV_INPUT, "Balance CV");
+        configInput(OFFSET_CV_INPUT, "Offset CV");
+        configInput(IN_A_INPUT, "Channel A");
+        configInput(IN_B_INPUT, "Channel B");
+        configOutput(OUT_POS_OUTPUT, "Positive Signal");
+        configOutput(OUT_NEG_OUTPUT, "Negative Signal");
+
+        configBypass(IN_A_INPUT, OUT_POS_OUTPUT);
 
         quality = ECO;
         delayMode = DI;

--- a/src/holt.cpp
+++ b/src/holt.cpp
@@ -3,7 +3,7 @@ Holt
 ------
 VCV Rack module based on Holt by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - mono
@@ -16,7 +16,7 @@ Changes/Additions:
 See ./LICENSE.md for all licenses
 ************************************************************************************************/
 
-/* 
+/*
     Note: for the sake of porting variety, this one encapsulates the entire audio plugin as its own entity
     Advantages: cleaner module logic, way easier and less messy handling of polyphony
     Drawbacks: possibly sliiightly less speedy
@@ -261,6 +261,14 @@ struct Holt : Module {
         configParam(FREQUENCY_PARAM, 0.f, 1.f, 1.f, "Frequency");
         configParam(RESONANCE_PARAM, 0.f, 1.f, 0.f, "Resonance");
         configParam(POLES_PARAM, 0.f, 1.f, 1.f, "Poles");
+
+        configInput(FREQUENCY_CV_INPUT, "Frequency CV");
+        configInput(RESONANCE_CV_INPUT, "Resonance CV");
+        configInput(POLES_CV_INPUT, "Poles CV");
+        configInput(IN_INPUT, "Signal");
+        configOutput(OUT_OUTPUT, "Signal");
+
+        configBypass(IN_INPUT, OUT_OUTPUT);
 
         quality = loadQuality();
     }

--- a/src/hombre.cpp
+++ b/src/hombre.cpp
@@ -3,7 +3,7 @@ Hombre
 ------
 VCV Rack module based on Hombre by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - mono
@@ -67,6 +67,13 @@ struct Hombre : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(VOICING_PARAM, 0.f, 1.f, 0.5f, "Voicing");
         configParam(INTENSITY_PARAM, 0.f, 1.f, 0.5f, "Intensity");
+
+        configInput(VOICING_CV_INPUT, "Voicing CV");
+        configInput(INTENSITY_CV_INPUT, "Intensity CV");
+        configInput(IN_INPUT, "Signal");
+        configOutput(OUT_OUTPUT, "Signal");
+
+        configBypass(IN_INPUT, OUT_OUTPUT);
 
         quality = loadQuality();
         onReset();

--- a/src/interstage.cpp
+++ b/src/interstage.cpp
@@ -3,7 +3,7 @@ Interstage
 --------
 VCV Rack module based on Interstage by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - polyphonic
@@ -71,6 +71,14 @@ struct Interstage : Module {
     Interstage()
     {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
+
+        configInput(IN_L_INPUT, "Signal L");
+        configInput(IN_R_INPUT, "Signal R");
+        configOutput(OUT_L_OUTPUT, "Signal L");
+        configOutput(OUT_R_OUTPUT, "Signal R");
+
+        configBypass(IN_L_INPUT, OUT_L_OUTPUT);
+        configBypass(IN_R_INPUT, OUT_R_OUTPUT);
 
         quality = loadQuality();
         onReset();

--- a/src/monitoring.cpp
+++ b/src/monitoring.cpp
@@ -88,7 +88,15 @@ struct Monitoring : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(MODE_PARAM, 0.f, 8.f, 0.f, "Mode");
         configParam(CANS_PARAM, 0.f, 4.f, 0.f, "Cans");
-        configParam(DITHER_PARAM, 0.f, 2.f, 0.f, "Dither");
+        configSwitch(DITHER_PARAM, 0.f, 2.f, 0.f, "Dither", {"Off", "24 bit", "16 bit"});
+
+        configInput(IN_L_INPUT, "Signal L");
+        configInput(IN_R_INPUT, "Signal R");
+        configOutput(OUT_L_OUTPUT, "Signal L");
+        configOutput(OUT_R_OUTPUT, "Signal R");
+
+        configBypass(IN_L_INPUT, OUT_L_OUTPUT);
+        configBypass(IN_R_INPUT, OUT_R_OUTPUT);
 
         onReset();
     }

--- a/src/mv.cpp
+++ b/src/mv.cpp
@@ -3,7 +3,7 @@ MV
 --
 VCV Rack module based on MV by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - CV inputs for depth, regeneration, brightness and dry/wet
@@ -213,6 +213,18 @@ struct Mv : Module {
         configParam(BRIGHT_CV_PARAM, -1.f, 1.f, 0.f, "Brightness CV");
         configParam(DRYWET_CV_PARAM, -1.f, 1.f, 0.f, "Dry/Wet CV");
         configParam(REGEN_CV_PARAM, -1.f, 1.f, 0.f, "Regeneration CV");
+
+        configInput(DEPTH_CV_INPUT, "Depth CV");
+        configInput(BRIGHT_CV_INPUT, "Brightness CV");
+        configInput(DRYWET_CV_INPUT, "Dry/wet CV");
+        configInput(REGEN_CV_INPUT, "Regeneration CV");
+        configInput(IN_L_INPUT, "Signal L");
+        configInput(IN_R_INPUT, "Signal R");
+        configOutput(OUT_L_OUTPUT, "Signal L");
+        configOutput(OUT_R_OUTPUT, "Signal R");
+
+        configBypass(IN_L_INPUT, OUT_L_OUTPUT);
+        configBypass(IN_R_INPUT, OUT_R_OUTPUT);
 
         quality = loadQuality();
         onReset();
@@ -599,7 +611,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgAR = avgtemp;
                 }
-                //allpass filter A
+            //allpass filter A
             case 25:
                 allpasstemp = alpB - 1;
                 if (allpasstemp < 0 || allpasstemp > delayB) {
@@ -630,7 +642,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgBR = avgtemp;
                 }
-                //allpass filter B
+            //allpass filter B
             case 24:
                 allpasstemp = alpC - 1;
                 if (allpasstemp < 0 || allpasstemp > delayC) {
@@ -661,7 +673,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgCR = avgtemp;
                 }
-                //allpass filter C
+            //allpass filter C
             case 23:
                 allpasstemp = alpD - 1;
                 if (allpasstemp < 0 || allpasstemp > delayD) {
@@ -692,7 +704,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgDR = avgtemp;
                 }
-                //allpass filter D
+            //allpass filter D
             case 22:
                 allpasstemp = alpE - 1;
                 if (allpasstemp < 0 || allpasstemp > delayE) {
@@ -723,7 +735,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgER = avgtemp;
                 }
-                //allpass filter E
+            //allpass filter E
             case 21:
                 allpasstemp = alpF - 1;
                 if (allpasstemp < 0 || allpasstemp > delayF) {
@@ -754,7 +766,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgFR = avgtemp;
                 }
-                //allpass filter F
+            //allpass filter F
             case 20:
                 allpasstemp = alpG - 1;
                 if (allpasstemp < 0 || allpasstemp > delayG) {
@@ -785,7 +797,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgGR = avgtemp;
                 }
-                //allpass filter G
+            //allpass filter G
             case 19:
                 allpasstemp = alpH - 1;
                 if (allpasstemp < 0 || allpasstemp > delayH) {
@@ -816,7 +828,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgHR = avgtemp;
                 }
-                //allpass filter H
+            //allpass filter H
             case 18:
                 allpasstemp = alpI - 1;
                 if (allpasstemp < 0 || allpasstemp > delayI) {
@@ -847,7 +859,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgIR = avgtemp;
                 }
-                //allpass filter I
+            //allpass filter I
             case 17:
                 allpasstemp = alpJ - 1;
                 if (allpasstemp < 0 || allpasstemp > delayJ) {
@@ -878,7 +890,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgJR = avgtemp;
                 }
-                //allpass filter J
+            //allpass filter J
             case 16:
                 allpasstemp = alpK - 1;
                 if (allpasstemp < 0 || allpasstemp > delayK) {
@@ -909,7 +921,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgKR = avgtemp;
                 }
-                //allpass filter K
+            //allpass filter K
             case 15:
                 allpasstemp = alpL - 1;
                 if (allpasstemp < 0 || allpasstemp > delayL) {
@@ -940,7 +952,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgLR = avgtemp;
                 }
-                //allpass filter L
+            //allpass filter L
             case 14:
                 allpasstemp = alpM - 1;
                 if (allpasstemp < 0 || allpasstemp > delayM) {
@@ -971,7 +983,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgMR = avgtemp;
                 }
-                //allpass filter M
+            //allpass filter M
             case 13:
                 allpasstemp = alpN - 1;
                 if (allpasstemp < 0 || allpasstemp > delayN) {
@@ -1002,7 +1014,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgNR = avgtemp;
                 }
-                //allpass filter N
+            //allpass filter N
             case 12:
                 allpasstemp = alpO - 1;
                 if (allpasstemp < 0 || allpasstemp > delayO) {
@@ -1033,7 +1045,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgOR = avgtemp;
                 }
-                //allpass filter O
+            //allpass filter O
             case 11:
                 allpasstemp = alpP - 1;
                 if (allpasstemp < 0 || allpasstemp > delayP) {
@@ -1064,7 +1076,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgPR = avgtemp;
                 }
-                //allpass filter P
+            //allpass filter P
             case 10:
                 allpasstemp = alpQ - 1;
                 if (allpasstemp < 0 || allpasstemp > delayQ) {
@@ -1095,7 +1107,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgQR = avgtemp;
                 }
-                //allpass filter Q
+            //allpass filter Q
             case 9:
                 allpasstemp = alpR - 1;
                 if (allpasstemp < 0 || allpasstemp > delayR) {
@@ -1126,7 +1138,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgRR = avgtemp;
                 }
-                //allpass filter R
+            //allpass filter R
             case 8:
                 allpasstemp = alpS - 1;
                 if (allpasstemp < 0 || allpasstemp > delayS) {
@@ -1157,7 +1169,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgSR = avgtemp;
                 }
-                //allpass filter S
+            //allpass filter S
             case 7:
                 allpasstemp = alpT - 1;
                 if (allpasstemp < 0 || allpasstemp > delayT) {
@@ -1188,7 +1200,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgTR = avgtemp;
                 }
-                //allpass filter T
+            //allpass filter T
             case 6:
                 allpasstemp = alpU - 1;
                 if (allpasstemp < 0 || allpasstemp > delayU) {
@@ -1219,7 +1231,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgUR = avgtemp;
                 }
-                //allpass filter U
+            //allpass filter U
             case 5:
                 allpasstemp = alpV - 1;
                 if (allpasstemp < 0 || allpasstemp > delayV) {
@@ -1250,7 +1262,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgVR = avgtemp;
                 }
-                //allpass filter V
+            //allpass filter V
             case 4:
                 allpasstemp = alpW - 1;
                 if (allpasstemp < 0 || allpasstemp > delayW) {
@@ -1281,7 +1293,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgWR = avgtemp;
                 }
-                //allpass filter W
+            //allpass filter W
             case 3:
                 allpasstemp = alpX - 1;
                 if (allpasstemp < 0 || allpasstemp > delayX) {
@@ -1312,7 +1324,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgXR = avgtemp;
                 }
-                //allpass filter X
+            //allpass filter X
             case 2:
                 allpasstemp = alpY - 1;
                 if (allpasstemp < 0 || allpasstemp > delayY) {
@@ -1343,7 +1355,7 @@ struct Mv : Module {
                     inputSampleR *= 0.5;
                     avgYR = avgtemp;
                 }
-                //allpass filter Y
+            //allpass filter Y
             case 1:
                 allpasstemp = alpZ - 1;
                 if (allpasstemp < 0 || allpasstemp > delayZ) {

--- a/src/rasp.cpp
+++ b/src/rasp.cpp
@@ -3,7 +3,7 @@ Rasp
 ----
 VCV Rack module based on Slew/Slew2/Slew3 and Acceleration by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - mono
@@ -76,6 +76,15 @@ struct Rasp : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(CLAMP_PARAM, 0.f, 1.f, 0.f, "Clamp", " %", 0.f, 100.f);
         configParam(LIMIT_PARAM, 0.f, 1.f, 0.f, "Limit", " %", 0.f, 100.f);
+
+        configInput(CLAMP_CV_INPUT, "Clamp CV");
+        configInput(LIMIT_CV_INPUT, "Limit CV");
+        configInput(IN_INPUT, "Signal");
+        configOutput(CLAMP_OUTPUT, "Clamp");
+        configOutput(LIMIT_OUTPUT, "Limit");
+
+        configBypass(IN_INPUT, CLAMP_OUTPUT);
+        configBypass(IN_INPUT, LIMIT_OUTPUT);
 
         quality = ECO;
         slewType = SLEW2;

--- a/src/reseq.cpp
+++ b/src/reseq.cpp
@@ -3,7 +3,7 @@ ResEQ
 ------
 VCV Rack module based on ResEQ by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - 4 frequency beams instead of 8
@@ -81,6 +81,16 @@ struct Reseq : Module {
             configParam(RESO_PARAMS + i, 0.f, 1.f, 0.f, string::f("Reso %d", i + 1), "%", 0, 100);
         }
         configParam(DRYWET_PARAM, 0.f, 1.f, 1.f, "Dry/Wet");
+
+        configInput(RESO_CV_INPUTS + 0, "Reso I CV");
+        configInput(RESO_CV_INPUTS + 1, "Reso II CV");
+        configInput(RESO_CV_INPUTS + 2, "Reso III CV");
+        configInput(RESO_CV_INPUTS + 3, "Reso IV CV");
+        configInput(DRYWET_CV_INPUT, "Dry/wet CV");
+        configInput(IN_INPUT, "Signal");
+        configOutput(OUT_OUTPUT, "Signal");
+
+        configBypass(IN_INPUT, OUT_OUTPUT);
 
         quality = loadQuality();
         onReset();

--- a/src/tape.cpp
+++ b/src/tape.cpp
@@ -3,7 +3,7 @@ Tape
 ----
 VCV Rack module based on Tape by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - cv inputs for slam and bump
@@ -66,6 +66,16 @@ struct Tape : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(SLAM_PARAM, 0.f, 1.f, 0.5f, "Slam", "%", 0, 100);
         configParam(BUMP_PARAM, 0.f, 1.f, 0.5f, "Bump", "%", 0, 100);
+
+        configInput(SLAM_CV_INPUT, "Slam CV");
+        configInput(BUMP_CV_INPUT, "Bump CV");
+        configInput(IN_L_INPUT, "Signal L");
+        configInput(IN_R_INPUT, "Signal R");
+        configOutput(OUT_L_OUTPUT, "Signal L");
+        configOutput(OUT_R_OUTPUT, "Signal R");
+
+        configBypass(IN_L_INPUT, OUT_L_OUTPUT);
+        configBypass(IN_R_INPUT, OUT_R_OUTPUT);
 
         quality = loadQuality();
         onReset();

--- a/src/tremolo.cpp
+++ b/src/tremolo.cpp
@@ -4,7 +4,7 @@ Tremolo
 -------
 VCV Rack module based on Tremolo by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
 - CV inputs for speed and depth
@@ -75,6 +75,14 @@ struct Tremolo : Module {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(SPEED_PARAM, 0.f, 1.f, 0.f, "Speed");
         configParam(DEPTH_PARAM, 0.f, 1.f, 0.f, "Depth");
+
+        configInput(CLOCK_CV_INPUT, "Clock CV");
+        configInput(SPEED_CV_INPUT, "Speed CV");
+        configInput(DEPTH_CV_INPUT, "Depth CV");
+        configInput(IN_INPUT, "Signal");
+        configOutput(OUT_OUTPUT, "Signal");
+
+        configBypass(IN_INPUT, OUT_OUTPUT);
 
         quality = loadQuality();
         onReset();

--- a/src/vibrato.cpp
+++ b/src/vibrato.cpp
@@ -3,10 +3,10 @@ Vibrato
 -------
 VCV Rack module based on Vibrato by Chris Johnson from Airwindows <www.airwindows.com>
 
-Ported and designed by Jens Robert Janke 
+Ported and designed by Jens Robert Janke
 
 Changes/Additions:
-- CV inputs for speed, depth, fmspeed, fmdepth and inv/wet 
+- CV inputs for speed, depth, fmspeed, fmdepth and inv/wet
 - trigger outputs (EOC) for speed and fmspeed
 - polyphonic
 
@@ -99,6 +99,18 @@ struct Vibrato : Module {
         configParam(DEPTH_PARAM, 0.f, 1.f, 0.f, "Depth");
         configParam(FMDEPTH_PARAM, 0.f, 1.f, 0.f, "FM Depth");
         configParam(INVWET_PARAM, 0.f, 1.f, 0.5f, "Inv/Wet");
+
+        configInput(SPEED_CV_INPUT, "Speed CV");
+        configInput(DEPTH_CV_INPUT, "Depth CV");
+        configInput(FMSPEED_CV_INPUT, "FM Speed CV");
+        configInput(FMDEPTH_CV_INPUT, "FM Depth CV");
+        configInput(INVWET_CV_INPUT, "Inv/Wet CV");
+        configInput(IN_INPUT, "Signal");
+        configOutput(OUT_OUTPUT, "Signal");
+        configOutput(EOC_OUTPUT, "EOC");
+        configOutput(EOC_FM_OUTPUT, "FM EOC");
+
+        configBypass(IN_INPUT, OUT_OUTPUT);
 
         quality = loadQuality();
         onReset();


### PR DESCRIPTION
Hi, these modules are great, so I thought I would help get ready for Rack v2

Summary of changes:
 - Bump version to 2.x in plugin.json
 - Add labels for inputs and outputs (part of Rack 2 API is to show details of module items when hovering/right clicking)
 - Add appropriate bypass configuration (defines a passthrough of signal when the module is bypassed)
 - Minor cleanup in a few areas (trailing spaces, correcting indentation)
 - Fix warning with return value in Chorus module (return `0.0f` even if input is not connected)